### PR TITLE
Fix example3 and CuPy issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ WARNING: Do not use anti-aliasing for the green channel ! The shades produced ar
 4. If prompted to install requirements, accept (or install requirements using pip -r requirements.txt)
 5. Right click on one of the examples in wave_sim2d/examples and select run
 
-
+NOTE: If you have issues installing the `cupy` library
+1. Make sure you have the `nvidia-cuda-toolkit` installed. 
+You can check it by running `nvcc --version`.
+1. In the *requirements.txt* file, replace `cupy` by `cupy-cuda[version-number]x`. 
+   Where the version number displayed when running `nvcc --version` (example: `cupy-cuda11x`).
 
 
 

--- a/wave_sim2d/examples/example3.py
+++ b/wave_sim2d/examples/example3.py
@@ -45,6 +45,9 @@ class MovingCharge(sim.SceneObject):
         # no changes to the refractive index or dampening field required for this class
         pass
 
+    def render_visualization(self, image: np.ndarray):
+        pass
+
     def update_field(self, field, t):
         fade_in = math.sin(min(t*0.1, math.pi/2))
 


### PR DESCRIPTION
This pull request contains:

1. Small fix for example 3. 

    Issue: `MovingCharge`  did not implement the `render_visualization` abstract method from the `SceneObject` class. 
    Fix: Added an empty definition for `render_visualization`.

2. Added note in README for cupy dependency issue.
    
    Issue: In some Linux distributions, CuPy does not seem to find the right path for cuda libraries (even when specified).
    Fix: Added a note  in README to use precompiled binary packages if needed.